### PR TITLE
Fix Week 1 seeding and clean game preparation

### DIFF
--- a/R/prepare_games.R
+++ b/R/prepare_games.R
@@ -50,11 +50,16 @@ prepare_games <- function(start_year,
         "spread_line","total_line",
         "home_spread_odds","away_spread_odds",
         "under_odds","over_odds",
-        "div_game","roof","surface","temp","wind",
+        "div_game","roof","surface",
         "home_coach","away_coach",
         "referee","stadium_id","stadium"
       )))
-  ) %>% dplyr::distinct()
+  ) %>%
+    dplyr::distinct() %>%
+    dplyr::mutate(
+      home_team = clean_team_name(home_team),
+      away_team = clean_team_name(away_team)
+    )
   
   cat("Available schedule features: ",
       paste(names(sched), collapse = ", "), "\n")
@@ -63,15 +68,12 @@ prepare_games <- function(start_year,
         round(mean(!is.na(sched$referee) & sched$referee != "")*100), "% of games\n")
   }
 
-  # Restrict schedule to seasons, weeks, and teams present in weekly_data
+  # Restrict schedule to seasons/weeks present in weekly_data but keep all teams
   valid_seasons <- unique(weekly_data$season)
   valid_weeks <- unique(weekly_data$week)
-  valid_teams <- unique(weekly_data$posteam)
   sched <- sched %>%
     dplyr::filter(season %in% valid_seasons,
-                  week %in% valid_weeks,
-                  home_team %in% valid_teams,
-                  away_team %in% valid_teams)
+                  week %in% valid_weeks)
   
   # ------------------ 2) WEEKLY → LAGGED FEATURES ------------------
   # Keys that must NEVER be lagged
@@ -80,7 +82,7 @@ prepare_games <- function(start_year,
   
   # Pre-game columns that should NOT be lagged if present in weekly_data
   pregame_cols <- intersect(c(
-    "spread_line","total_line","div_game","roof","surface","temp","wind"
+    "spread_line","total_line","div_game","roof","surface"
   ), names(weekly_data))
   
   # Numeric columns eligible for lag, excluding keys & pregame
@@ -124,10 +126,12 @@ prepare_games <- function(start_year,
   # Build home/away frames (prefix all non-key columns)
   base_cols <- setdiff(names(weekly_lag), key_cols)
   home_df <- weekly_lag %>%
+    dplyr::select(season, week, posteam, dplyr::all_of(base_cols)) %>%
     dplyr::rename(home_team = posteam) %>%
     dplyr::rename_with(~ paste0("home.", .x), .cols = dplyr::all_of(base_cols))
 
   away_df <- weekly_lag %>%
+    dplyr::select(season, week, posteam, dplyr::all_of(base_cols)) %>%
     dplyr::rename(away_team = posteam) %>%
     dplyr::rename_with(~ paste0("away.", .x), .cols = dplyr::all_of(base_cols))
 

--- a/R/prepare_weekly.R
+++ b/R/prepare_weekly.R
@@ -21,7 +21,12 @@ prepare_weekly <- function(years) {
       suppressMessages(nflfastR::load_pbp(year))
     })
     # Filter out plays without a valid posteam or defteam
-    pbp_data <- pbp_data %>% filter(!is.na(posteam) & !is.na(defteam))
+    pbp_data <- pbp_data %>%
+      filter(!is.na(posteam) & !is.na(defteam)) %>%
+      mutate(
+        posteam = clean_team_name(posteam),
+        defteam = clean_team_name(defteam)
+      )
 
     first_appearances <- pbp_data %>%
       group_by(game_id) %>%

--- a/R/update_games.R
+++ b/R/update_games.R
@@ -62,8 +62,8 @@ update_games <- function(years,
   } else {
     min(years_to_process):max(years_to_process)
   }
-  # guard: don't fall before the overall min requested year
-  weekly_years <- weekly_years[weekly_years >= min(years)]
+  # guard: allow previous season for carry-over when seeding Week 1
+  weekly_years <- weekly_years[weekly_years >= (min(years) - 1L)]
   
   weekly_data <- prepare_weekly(weekly_years)
   


### PR DESCRIPTION
## Summary
- preserve previous season when seeding Week 1 stats
- relax schedule team filtering and drop duplicate game identifiers
- exclude weather fields (Not complete data
- remove outdated model grid script
- clean team names during weekly and game preparation to align joins