### PR TITLE
Fix Week 1 seeding and clean game preparation

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -88,7 +88,12 @@ NFL_TEAM_MAPPINGS <- c(
   "Seattle Seahawks" = "SEA",
   "Tampa Bay Buccaneers" = "TB",
   "Tennessee Titans" = "TEN",
-  "Washington Commanders" = "WAS"
+  "Washington Commanders" = "WAS",
+  # legacy abbreviations mapped to current teams
+  "OAK" = "LV",
+  "SD"  = "LAC",
+  "STL" = "LA",
+  "WSH" = "WAS"
 )
 
 

--- a/R/prepare_weekly.R
+++ b/R/prepare_weekly.R
@@ -21,7 +21,12 @@ prepare_weekly <- function(years) {
       suppressMessages(nflfastR::load_pbp(year))
     })
     # Filter out plays without a valid posteam or defteam
-    pbp_data <- pbp_data %>% filter(!is.na(posteam) & !is.na(defteam))
+    pbp_data <- pbp_data %>%
+      filter(!is.na(posteam) & !is.na(defteam)) %>%
+      mutate(
+        posteam = clean_team_name(posteam),
+        defteam = clean_team_name(defteam)
+      )
 
     first_appearances <- pbp_data %>%
       group_by(game_id) %>%

--- a/R/update_games.R
+++ b/R/update_games.R
@@ -62,8 +62,8 @@ update_games <- function(years,
   } else {
     min(years_to_process):max(years_to_process)
   }
-  # guard: don't fall before the overall min requested year
-  weekly_years <- weekly_years[weekly_years >= min(years)]
+  # guard: allow previous season for carry-over when seeding Week 1
+  weekly_years <- weekly_years[weekly_years >= (min(years) - 1L)]
   
   weekly_data <- prepare_weekly(weekly_years)
   
@@ -94,6 +94,10 @@ update_games <- function(years,
   }
   
   combined <- combined %>%
+    mutate(game_id = dplyr::coalesce(.data$game_id, .data$game_id.x, .data$game_id.y)) %>%
+    select(-dplyr::any_of(c("game_id.x","game_id.y","home.game_id","away.game_id",
+                            "home.posteam_type","away.posteam_type",
+                            "posteam_type.x","posteam_type.y"))) %>%
     distinct(season, week, home_team, away_team, game_id, .keep_all = TRUE) %>%
     arrange(season, week, home_team, away_team)
   


### PR DESCRIPTION
## Summary
- map legacy team abbreviations (OAK, SD, STL, WSH) to current franchises
- strip duplicate identifiers and posteam type remnants when merging game data
- preserve a single game_id after joins and week‑1 seeding