### PR TITLE
Fix Week 1 seeding and clean game preparation

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -41,14 +41,6 @@ METRICS <- c(
   "def_third_down_conversion_rate", "def_fourth_down_conversion_rate", "def_red_zone_conversion_rate"
 )
 
-# Team abbreviation mapping
-TEAM_MAPPING <- list(
-  "SD" = "LAC",
-  "STL" = "LA",
-  "OAK" = "LV"
-)
-
-
 #' NFL Team Name Mappings
 #'
 #' A named vector mapping team abbreviations to full team names
@@ -88,7 +80,12 @@ NFL_TEAM_MAPPINGS <- c(
   "Seattle Seahawks" = "SEA",
   "Tampa Bay Buccaneers" = "TB",
   "Tennessee Titans" = "TEN",
-  "Washington Commanders" = "WAS"
+  "Washington Commanders" = "WAS",
+  # legacy abbreviations mapped to current teams
+  "OAK" = "LV",
+  "SD"  = "LAC",
+  "STL" = "LA",
+  "WSH" = "WAS"
 )
 
 
@@ -98,8 +95,7 @@ NFL_TEAM_MAPPINGS <- c(
 #' @return Character string of cleaned team name
 #' @export
 clean_team_name <- function(team_name) {
-  if(team_name %in% names(NFL_TEAM_MAPPINGS)) {
-    return(NFL_TEAM_MAPPINGS[team_name])
-  }
+  mapped <- NFL_TEAM_MAPPINGS[team_name]
+  team_name <- ifelse(is.na(mapped), team_name, unname(mapped))
   return(team_name)
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -26,6 +26,7 @@ map_team_abbreviation <- function(abbr) {
     abbr == "SD"  ~ "LAC",
     abbr == "STL" ~ "LA",
     abbr == "OAK" ~ "LV",
+    abbr == "WSH" ~ "WAS",
     TRUE ~ abbr
   )
 }

--- a/R/prepare_games.R
+++ b/R/prepare_games.R
@@ -50,11 +50,16 @@ prepare_games <- function(start_year,
         "spread_line","total_line",
         "home_spread_odds","away_spread_odds",
         "under_odds","over_odds",
-        "div_game","roof","surface","temp","wind",
+        "div_game","roof","surface",
         "home_coach","away_coach",
         "referee","stadium_id","stadium"
       )))
-  ) %>% dplyr::distinct()
+  ) %>%
+    dplyr::distinct() %>%
+    dplyr::mutate(
+      home_team = map_team_abbreviation(home_team),
+      away_team = map_team_abbreviation(away_team)
+    )
   
   cat("Available schedule features: ",
       paste(names(sched), collapse = ", "), "\n")
@@ -63,15 +68,23 @@ prepare_games <- function(start_year,
         round(mean(!is.na(sched$referee) & sched$referee != "")*100), "% of games\n")
   }
 
-  # Restrict schedule to seasons, weeks, and teams present in weekly_data
+  # Ensure prior season exists for Week 1 seeding
+  if (seed_week1 && (start_year - 1L) %in% years && !((start_year - 1L) %in% weekly_data$season)) {
+    weekly_data <- dplyr::bind_rows(prepare_weekly(start_year - 1L), weekly_data)
+  }
+
+  # Map team abbreviations in weekly data and drop identifier columns
+  if ("posteam" %in% names(weekly_data)) {
+    weekly_data$posteam <- map_team_abbreviation(weekly_data$posteam)
+  }
+  weekly_data <- weekly_data %>% dplyr::select(-dplyr::any_of(c("game_id", "posteam_type")))
+
+  # Restrict schedule to seasons/weeks present in weekly_data but keep all teams
   valid_seasons <- unique(weekly_data$season)
   valid_weeks <- unique(weekly_data$week)
-  valid_teams <- unique(weekly_data$posteam)
   sched <- sched %>%
     dplyr::filter(season %in% valid_seasons,
-                  week %in% valid_weeks,
-                  home_team %in% valid_teams,
-                  away_team %in% valid_teams)
+                  week %in% valid_weeks)
   
   # ------------------ 2) WEEKLY → LAGGED FEATURES ------------------
   # Keys that must NEVER be lagged
@@ -80,7 +93,7 @@ prepare_games <- function(start_year,
   
   # Pre-game columns that should NOT be lagged if present in weekly_data
   pregame_cols <- intersect(c(
-    "spread_line","total_line","div_game","roof","surface","temp","wind"
+    "spread_line","total_line","div_game","roof","surface"
   ), names(weekly_data))
   
   # Numeric columns eligible for lag, excluding keys & pregame
@@ -124,10 +137,12 @@ prepare_games <- function(start_year,
   # Build home/away frames (prefix all non-key columns)
   base_cols <- setdiff(names(weekly_lag), key_cols)
   home_df <- weekly_lag %>%
+    dplyr::select(season, week, posteam, dplyr::all_of(base_cols)) %>%
     dplyr::rename(home_team = posteam) %>%
     dplyr::rename_with(~ paste0("home.", .x), .cols = dplyr::all_of(base_cols))
 
   away_df <- weekly_lag %>%
+    dplyr::select(season, week, posteam, dplyr::all_of(base_cols)) %>%
     dplyr::rename(away_team = posteam) %>%
     dplyr::rename_with(~ paste0("away.", .x), .cols = dplyr::all_of(base_cols))
 
@@ -142,7 +157,14 @@ prepare_games <- function(start_year,
       away_df,
       by = intersect(c("season","week","away_team"), names(away_df))
     )
-  
+
+  # Remove any residual identifiers from weekly joins (should rarely exist)
+  games <- games %>%
+    dplyr::select(-dplyr::any_of(c(
+      "home.game_id", "away.game_id",
+      "home.posteam_type", "away.posteam_type"
+    )))
+
   # Ensure away.spread_line exists
   if ("spread_line" %in% names(games)) {
     games <- games %>% dplyr::mutate(away.spread_line = -spread_line)
@@ -290,7 +312,7 @@ prepare_games <- function(start_year,
       }
     }
   }
-  
+
   # ------------------ 6) Derived outcomes & handy features ------------------
   games <- games %>%
     dplyr::mutate(

--- a/R/prepare_weekly.R
+++ b/R/prepare_weekly.R
@@ -20,8 +20,13 @@ prepare_weekly <- function(years) {
     pbp_data <- map_df(years, function(year) {
       suppressMessages(nflfastR::load_pbp(year))
     })
-    # Filter out plays without a valid posteam or defteam
-    pbp_data <- pbp_data %>% filter(!is.na(posteam) & !is.na(defteam))
+    # Filter out plays without a valid posteam or defteam and map legacy abbreviations
+    pbp_data <- pbp_data %>%
+      filter(!is.na(posteam) & !is.na(defteam)) %>%
+      mutate(
+        posteam = map_team_abbreviation(posteam),
+        defteam = map_team_abbreviation(defteam)
+      )
 
     first_appearances <- pbp_data %>%
       group_by(game_id) %>%

--- a/R/update_games.R
+++ b/R/update_games.R
@@ -62,8 +62,9 @@ update_games <- function(years,
   } else {
     min(years_to_process):max(years_to_process)
   }
-  # guard: don't fall before the overall min requested year
-  weekly_years <- weekly_years[weekly_years >= min(years)]
+  # guard: allow previous season for carry-over when seeding Week 1
+  # but prevent fetching seasons before the earliest requested year
+  weekly_years <- weekly_years[weekly_years >= (min(years) - 1L)]
   
   weekly_data <- prepare_weekly(weekly_years)
   
@@ -94,6 +95,10 @@ update_games <- function(years,
   }
   
   combined <- combined %>%
+    mutate(game_id = dplyr::coalesce(!!!dplyr::select(., dplyr::any_of(c("game_id","game_id.x","game_id.y"))))) %>%
+    select(-dplyr::any_of(c("game_id.x","game_id.y","home.game_id","away.game_id",
+                            "home.posteam_type","away.posteam_type",
+                            "posteam_type.x","posteam_type.y"))) %>%
     distinct(season, week, home_team, away_team, game_id, .keep_all = TRUE) %>%
     arrange(season, week, home_team, away_team)
   


### PR DESCRIPTION
## Summary
- map legacy team abbreviations (OAK, SD, STL, WSH) to current franchises at load time
- auto-append prior season data when seeding Week 1 and drop leftover identifiers from weekly joins
- ensure schedule and weekly data use updated abbreviations before lagging
- guard against creating duplicate `game_id` columns by excluding identifier fields from lagged features
- remove unused `TEAM_MAPPING` constant from constants

## Testing
- `Rscript scripts/run_all_tests.R` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d7cd7148332a83de9bac6aa7b4f